### PR TITLE
Test 3.2.4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3307,7 +3307,38 @@
       <properties>
         <hadoop.version>3.1.4-1.0-SNAPSHOT</hadoop.version>
         <curator.version>2.12.0</curator.version>
+        <!--
+          the declaration site above of these variables explains why we need to re-assign them here
+        -->
+        <hadoop-client-api.artifact>hadoop-client</hadoop-client-api.artifact>
+        <hadoop-client-runtime.artifact>hadoop-yarn-api</hadoop-client-runtime.artifact>
+        <hadoop-client-minicluster.artifact>hadoop-client</hadoop-client-minicluster.artifact>
       </properties>
+      <dependencies>
+        <dependency>
+          <groupId>org.apache.hadoop</groupId>
+          <artifactId>hadoop-yarn-common</artifactId>
+        </dependency>
+        <dependency>
+          <groupId>org.apache.hadoop</groupId>
+          <artifactId>hadoop-yarn-server-web-proxy</artifactId>
+        </dependency>
+        <dependency>
+          <groupId>org.apache.hadoop</groupId>
+          <artifactId>hadoop-yarn-client</artifactId>
+        </dependency>
+        <dependency>
+          <groupId>org.apache.hadoop</groupId>
+          <artifactId>hadoop-yarn-server-resourcemanager</artifactId>
+          <scope>test</scope>
+        </dependency>
+        <dependency>
+          <groupId>org.apache.hadoop</groupId>
+          <artifactId>hadoop-yarn-server-tests</artifactId>
+          <classifier>tests</classifier>
+          <scope>test</scope>
+        </dependency>
+      </dependencies>
     </profile>
 
     <profile>

--- a/tdp/README.md
+++ b/tdp/README.md
@@ -17,6 +17,7 @@ The command generates a `.tar.gz` file of the release at `./spark-3.2.2-TDP-0.1.
 ## Testing parameters
 
 ```bash
+export MAVEN_OPTS="-Xss64m -Xmx2g -XX:ReservedCodeCacheSize=1g"
 export DEFAULT_ARTIFACT_REPOSITORY="file:$HOME/.m2/repository/"
 ./build/mvn test -Phive -Phive-thriftserver -Pyarn -Phadoop-3.1 --fail-never
 ```

--- a/tdp/test-notes.md
+++ b/tdp/test-notes.md
@@ -21,7 +21,35 @@
      <properties>
        <hadoop.version>3.1.1-TDP-0.1.0-SNAPSHOT</hadoop.version>
        <curator.version>2.12.0</curator.version>
+       <hadoop-client-api.artifact>hadoop-client</hadoop-client-api.artifact>
+       <hadoop-client-runtime.artifact>hadoop-yarn-api</hadoop-client-runtime.artifact>
+       <hadoop-client-minicluster.artifact>hadoop-client</hadoop-client-minicluster.artifact>
      </properties>
+     <dependencies>
+       <dependency>
+         <groupId>org.apache.hadoop</groupId>
+         <artifactId>hadoop-yarn-common</artifactId>
+       </dependency>
+       <dependency>
+         <groupId>org.apache.hadoop</groupId>
+         <artifactId>hadoop-yarn-server-web-proxy</artifactId>
+       </dependency>
+       <dependency>
+         <groupId>org.apache.hadoop</groupId>
+         <artifactId>hadoop-yarn-client</artifactId>
+       </dependency>
+       <dependency>
+         <groupId>org.apache.hadoop</groupId>
+         <artifactId>hadoop-yarn-server-resourcemanager</artifactId>
+         <scope>test</scope>
+       </dependency>
+       <dependency>
+         <groupId>org.apache.hadoop</groupId>
+         <artifactId>hadoop-yarn-server-tests</artifactId>
+         <classifier>tests</classifier>
+         <scope>test</scope>
+       </dependency>
+     </dependencies>
    </profile>
    ```
 


### PR DESCRIPTION
Relates to https://github.com/TOSIT-IO/TDP/pull/90. This PR mostly exists to track work of spark3.

I've pushed a new branch called 3.2.4-TDP on the repo. The branch was based on 3.2.4 tag of apache upstream.
I've tried to run the tests but some are failing, as they used with previous version of spark 3 in tdp 1.0.

I'd appreciate some help regarding testing this spark version. The PR includes work by nuttymoon to fix tests of spark 3.2.2.

